### PR TITLE
Support all changeConfig parameters

### DIFF
--- a/seatsio-ios/ConfigChange.swift
+++ b/seatsio-ios/ConfigChange.swift
@@ -10,6 +10,7 @@ public class ConfigChange: Encodable {
     var availableCategories: [String]?
     var unavailableCategories: [String]?
     var filteredCategories: [String]?
+    var pricing: [Pricing]?
     var channels: [String]?
 
     public func objectColor(_ objectColor: String) -> Self {
@@ -59,6 +60,11 @@ public class ConfigChange: Encodable {
 
     public func filteredCategories(_ filteredCategories: [String]) -> Self {
         self.filteredCategories = filteredCategories
+        return self
+    }
+
+    public func pricing(_ pricing: [Pricing]) -> Self {
+        self.pricing = pricing
         return self
     }
 

--- a/seatsio-ios/ConfigChange.swift
+++ b/seatsio-ios/ConfigChange.swift
@@ -4,6 +4,7 @@ public class ConfigChange: Encodable {
 
     var objectColor: String?
     var objectLabel: String?
+    var numberOfPlacesToSelect: Int?
     var maxSelectedObjects: AnyEncodable?
     var extraConfig: AnyEncodable?
     var unavailableCategories: [String]?
@@ -17,6 +18,11 @@ public class ConfigChange: Encodable {
 
     public func objectLabel(_ objectLabel: String) -> Self {
         self.objectLabel = objectLabel
+        return self
+    }
+
+    public func numberOfPlacesToSelect(_ numberOfPlacesToSelect: Int) -> Self {
+        self.numberOfPlacesToSelect = numberOfPlacesToSelect
         return self
     }
 

--- a/seatsio-ios/ConfigChange.swift
+++ b/seatsio-ios/ConfigChange.swift
@@ -7,9 +7,10 @@ public class ConfigChange: Encodable {
     var numberOfPlacesToSelect: Int?
     var maxSelectedObjects: AnyEncodable?
     var extraConfig: AnyEncodable?
-    var unavailableCategories: [String]?
     var availableCategories: [String]?
+    var unavailableCategories: [String]?
     var filteredCategories: [String]?
+    var channels: [String]?
 
     public func objectColor(_ objectColor: String) -> Self {
         self.objectColor = objectColor
@@ -58,6 +59,11 @@ public class ConfigChange: Encodable {
 
     public func filteredCategories(_ filteredCategories: [String]) -> Self {
         self.filteredCategories = filteredCategories
+        return self
+    }
+
+    public func channels(_ channels: [String]) -> Self {
+        self.channels = channels
         return self
     }
 }


### PR DESCRIPTION
`chart.changeConfig()` did not support a number of things we do support on the web version. 

This PR adds support for numberOfPlacesToSelect, pricing and channels